### PR TITLE
Determine out-of-bounds points by their contribution area instead of their center point

### DIFF
--- a/addon/components/heatmap-layer.js
+++ b/addon/components/heatmap-layer.js
@@ -8,11 +8,11 @@ let willUpdateData;
 
 export default BaseLayer.extend({
 
-	leafletOptions: [
-	  'backgroundColor', 'blur', 'gradient', 'latField', 'lngField', 'maxOpacity', 'minOpacity', 'radius', 'scaleRadius', 'useLocalExtrema', 'valueField', 'maxValue', 'minValue'
-	],
+  leafletOptions: [
+    'backgroundColor', 'blur', 'gradient', 'latField', 'lngField', 'maxOpacity', 'minOpacity', 'radius', 'scaleRadius', 'useLocalExtrema', 'valueField', 'maxValue', 'minValue'
+  ],
 
-	createLayer(){
+  createLayer(){
     return new HeatmapLayer(get(this, 'options'));
 
 	},

--- a/addon/layers/heatmap-layer.js
+++ b/addon/layers/heatmap-layer.js
@@ -117,9 +117,13 @@ export default L.Layer.extend({
     this._data.data.forEach((datapoint) => {
       const value = get(datapoint, valueField);
       const latlng = get(datapoint, 'latlng');
+      const radius = data.radius ? data.radius * radiusMultiplier : (this.cfg.radius || 2) * radiusMultiplier;
+
+      const mapSize = this._map.getSize();
+      const mapPadding = radius / Math.min(mapSize.x, mapSize.y);
 
       // we don't wanna render points that are not even on the map ;-)
-      if (!bounds.contains(latlng)) {
+      if (!bounds.pad(mapPadding).contains(latlng)) {
         return;
       }
 
@@ -132,7 +136,7 @@ export default L.Layer.extend({
           x: Math.round(point.x),
           y: Math.round(point.y),
           [valueField]: value,
-          radius: data.radius ? data.radius * radiusMultiplier : (this.cfg.radius || 2) * radiusMultiplier
+          radius: radius
         };
 
       latLngPoints.push(latlngPoint);


### PR DESCRIPTION
Addresses #4

I tried to make this as quick as possible, so in certain edge cases when blur is turned off they may disappear a pixel too early, but even then the effect is almost completely mitigated. With more normal blur settings I was unable to visually replicate the problem in #4.

I also tackled the linting error in `/components/heatmap-layer.js` mostly by accident, since I modified some of it for testing and my editor auto-fixed the mismatched tabs. ¯\_(ツ)_/¯