### PR TITLE
Update ember-composability-tools from v0.0.7 to v0.0.10 (fixing DEPRECATION warning)

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "broccoli-merge-trees": "^1.2.1",
     "ember-cli-babel": "^6.6.0",
     "ember-cli-version-checker": "^1.2.0",
-    "ember-composability-tools": "0.0.7",
+    "ember-composability-tools": "0.0.10",
     "heatmap.js": "^2.0.5"
   },
   "devDependencies": {


### PR DESCRIPTION
With ember-composability-tools@0.0.7 ember is giving a deprecation warning:
```
C:\appname\frontend> ember -v DEPRECATION
DEPRECATION: ember-cli-babel 5.x has been deprecated. Please upgrade to at least ember-cli-babel 6.6. Version 5.2.8 located: appname -> ember-leaflet-heatmap -> ember-composability-tools -> ember-cli-babel
DEPRECATION: ember-cli-babel 5.x has been deprecated. Please upgrade to at least ember-cli-babel 6.6. Version 5.2.8 located: appname -> ember-leaflet-heatmap -> ember-composability-tools -> ember-getowner-polyfill -> ember-cli-babel
DEPRECATION: ember-cli-babel 5.x has been deprecated. Please upgrade to at least ember-cli-babel 6.6. Version 5.2.8 located: appname -> ember-leaflet-heatmap -> ember-composability-tools -> ember-wormhole -> ember-cli-babel
ember-cli: 3.6.0
node: 8.9.3
os: win32 x64
```
This is fixed when using ember-composability-tools@0.0.10