### PR TITLE
Update ember-composabiltiy-tools to 0.0.11

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "broccoli-merge-trees": "^3.0.2",
     "ember-cli-babel": "^7.1.2",
     "ember-cli-version-checker": "^2.1.2",
-    "ember-composability-tools": "0.0.10",
+    "ember-composability-tools": "0.0.11",
     "fastboot-transform": "^0.1.2",
     "heatmap.js": "^2.0.5"
   },


### PR DESCRIPTION
Updated, as in ember-composability-tools@0.0.11 the array.new-array-wrapper deprecation is fixed.
See https://github.com/miguelcobain/ember-composability-tools/pull/20