### PR TITLE
Update ember-composability-tools to 0.0.12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: node_js
 node_js:
   # we recommend testing addons with the same minimum supported node version as Ember CLI
   # so that your addon works for all apps
-  - "6"
+  - "8"
 
 sudo: false
 dist: trusty

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "broccoli-merge-trees": "^3.0.2",
     "ember-cli-babel": "^7.1.2",
     "ember-cli-version-checker": "^2.1.2",
-    "ember-composability-tools": "0.0.11",
+    "ember-composability-tools": "0.0.12",
     "fastboot-transform": "^0.1.2",
     "heatmap.js": "^2.0.5"
   },


### PR DESCRIPTION
To keep in sync with ember-leaflet and to prevent dependency-lint errors.