### PR TITLE
Fix the ember deprecated exception with using getWithDefault.

### DIFF
--- a/addon/components/heatmap-layer.js
+++ b/addon/components/heatmap-layer.js
@@ -24,7 +24,7 @@ export default EmberLeafletBaseLayer.extend({
 
   setDataObservers() {
     A(['lat', 'lng', 'value']).forEach((property) => {
-      property = this.getWithDefault(`${property}Field`, property);
+      property = this.get(`${property}Field`) ?? property;
       this.addObserver(`data.@each.${property}`, this.dataPropertyChange);
     });
 

--- a/addon/layers/heatmap-layer.js
+++ b/addon/layers/heatmap-layer.js
@@ -110,7 +110,7 @@ if (typeof FastBoot === 'undefined') {
         return;
       }
 
-      const valueField = this.cfg.getWithDefault('valueField', 'value');
+      const valueField = this.cfg.get('valueField') ?? 'value';
 
       let latLngPoints = [],
         radiusMultiplier = get(this.cfg, 'scaleRadius') ? scale : 1,
@@ -158,9 +158,9 @@ if (typeof FastBoot === 'undefined') {
     },
 
     updateData(data) {
-      const latField = this.cfg.getWithDefault('latField', 'lat');
-      const lngField = this.cfg.getWithDefault('lngField', 'lng');
-      const valueField = this.cfg.getWithDefault('valueField', 'value');
+      const latField = this.cfg.get('latField') ?? 'lat';
+      const lngField = this.cfg.get('lngField') ?? 'lng';
+      const valueField = this.cfg.get('valueField') ?? 'value';
 
       let max = this._max,
         min = this._min;


### PR DESCRIPTION
The Ember deprecation description is in the link https://github.com/emberjs/rfcs/blob/master/text/0554-deprecate-getwithdefault.md. And it will cause javascript exception in the latest Ember version.